### PR TITLE
(#3) - import the plugin

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var Pouch = require('pouchdb');
 var Mapreduce = require('../');
+Pouch.plugin('mapreduce',Mapreduce);
 var should = require('chai').should();
 beforeEach(function(done){
   Pouch('testdb',function(err,d){


### PR DESCRIPTION
the coverage clinched it, when you don't reregister the plugin, the tests don't test this copy of map reduce, but when you do register it does test this one. 
