### PR TITLE
(#1198) - Allow 0/null as mapreduce keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function MapReduce(db) {
 
       if (options.startkey && pouchCollate(key, options.startkey) < 0) return;
       if (options.endkey && pouchCollate(key, options.endkey) > 0) return;
-      if (options.key && pouchCollate(key, options.key) !== 0) return;
+      if (typeof options.key !== 'undefined' && pouchCollate(key, options.key) !== 0) return;
 
       num_started++;
       if (options.include_docs) {


### PR DESCRIPTION
CouchDB allows 0 and null as separate keys in
mapreduce queries. This commit makes PouchDB behave like CouchDB.
Since this is a multi-repo change that affects pouchdb,
pouchdb-collate, and pouchdb-mapreduce, I wasn't really sure
how to structure this commit, so I'm just including the same
commit message in 3 separate commits.
