### PR TITLE
(#5) - fix _conflict assertion in tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -415,7 +415,7 @@ function tests(dbName) {
                 db.get(doc1._id, {conflicts: true}, function (err, res) {
                   should.exist(res._conflicts);
                   db.query(queryFun, function (err, res) {
-                    should.exist(res.rows[0].value);
+                    res.rows[0].value.should.equal(true);
                     pouch.destroy('testdb2', function () {
                       done();
                     });


### PR DESCRIPTION
This code will (almost) always work because it checks for existence of value. It should check for the value being true.
