### PR TITLE
(#52) - Provide dummy function if console.log undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var pouchCollate = require('pouchdb-collate');
 var Promise = typeof global.Promise === 'function' ? global.Promise : require('lie');
 var collate = pouchCollate.collate;
 var evalFunc = require('./evalfunc');
-var log = Function.prototype.bind.call(console.log, console);
+var log = (typeof console !== 'undefined') ?
+  Function.prototype.bind.call(console.log, console) : function() {};
 var processKey = function (key) {
   // Stringify keys since we want them as map keys (see #35)
   return JSON.stringify(pouchCollate.normalizeKey(key));


### PR DESCRIPTION
Turns out the firefox failures were legit, console is undefined in worker context in fx 25.0.1
