### PR TITLE
(#59) - Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "jshint": "~2.3.0",
     "mocha-as-promised": "~2.0.0",
     "chai-as-promised": "~4.1.0",
-    "bluebird": "^1.0.7"
+    "bluebird": "~1.0.7"
   }
 }


### PR DESCRIPTION
Looks like we accidentally put a caret
instead of a tilde.

npm install is giving me the predictable error:
Error: No compatible version found: bluebird@^1.0.7
