### PR TITLE
(#76) - mrview dbs self-destruct if parent dies

### DIFF
--- a/create-view.js
+++ b/create-view.js
@@ -32,6 +32,9 @@ module.exports = function (sourceDB, fullViewName, mapFun, reduceFun, cb) {
         if (err) {
           return cb(err);
         }
+        PouchDB.on(info.db_name, function () {
+          db.destroy();
+        });
         var view = new View(name, db, sourceDB, mapFun, reduceFun);
         view.db.get('_local/lastSeq', function (err, lastSeqDoc) {
           if (err) {


### PR DESCRIPTION
This was causing some errors in PouchDB's test suite due to mrview dbs not getting cleaned up after tests.
