### PR TITLE
(daleharvey/pouchdb#1658) - register dependent dbs

### DIFF
--- a/upsert.js
+++ b/upsert.js
@@ -1,0 +1,44 @@
+'use strict';
+var Promise = typeof global.Promise === 'function' ? global.Promise : require('lie');
+
+// this is essentially the "update sugar" function from daleharvey/pouchdb#1388
+function upsert(db, docId, diffFun) {
+  return new Promise(function (fullfil, reject) {
+    if (docId && typeof docId === 'object') {
+      docId = docId._id;
+    }
+    if (typeof docId !== 'string') {
+      return reject(new Error('doc id is required'));
+    }
+
+    db.get(docId, function (err, doc) {
+      if (err) {
+        if (err.name !== 'not_found') {
+          return reject(err);
+        }
+        return fullfil(tryAndPut(db, diffFun({_id : docId}), diffFun));
+      }
+      doc = diffFun(doc);
+      fullfil(tryAndPut(db, doc, diffFun));
+    });
+  });
+}
+
+function tryAndPut(db, doc, diffFun) {
+  return db.put(doc).then(null, function (err) {
+    if (err.name !== 'conflict') {
+      throw err;
+    }
+    return upsert(db, doc, diffFun);
+  });
+}
+
+module.exports = function (db, docId, diffFun, cb) {
+  if (typeof cb === 'function') {
+    upsert(db, docId, diffFun).then(function (resp) {
+      cb(null, resp);
+    }, cb);
+  } else {
+    return upsert(db, docId, diffFun);
+  }
+};

--- a/utils.js
+++ b/utils.js
@@ -22,36 +22,3 @@ exports.clone = function (obj) {
 };
 
 exports.inherits = require('inherits');
-
-// this is essentially the "update sugar" function from daleharvey/pouchdb#1388
-exports.retryUntilWritten = function (db, docId, diffFun, cb) {
-  if (docId && typeof docId === 'object') {
-    docId = docId._id;
-  }
-  if (typeof docId !== 'string') {
-    return cb(new Error('doc id is required'));
-  }
- 
-  db.get(docId, function (err, doc) {
-    if (err) {
-      if (err.name !== 'not_found') {
-        return cb(err);
-      }
-      return tryAndPut(db, diffFun({_id : docId}), diffFun, cb);
-    }
-    doc = diffFun(doc);
-    tryAndPut(db, doc, diffFun, cb);
-  });
-};
-
-function tryAndPut(db, doc, diffFun, cb) {
-  db.put(doc, function (err) {
-    if (err) {
-      if (err.name !== 'conflict') {
-        return cb(err);
-      }
-      return exports.retryUntilWritten(db, doc, diffFun, cb);
-    }
-    cb(null);
-  });
-}


### PR DESCRIPTION
This ensures that map/reduce's dependent dbs
are registered, so that PouchDB can clean them
up when their parent databases are destroyed.
