### PR TITLE
Small fix for versions of IE where (typeof console.log === 'object')

### DIFF
--- a/dist/pouchdb-mapreduce.js
+++ b/dist/pouchdb-mapreduce.js
@@ -13,7 +13,7 @@ var pouchCollate = require('pouchdb-collate');
 var Promise = typeof global.Promise === 'function' ? global.Promise : require('lie');
 var collate = pouchCollate.collate;
 var evalFunc = require('./evalfunc');
-var log = (typeof console !== 'undefined') ?
+var log = ((typeof console !== 'undefined') && (typeof console.log === 'function')) ?
   Function.prototype.bind.call(console.log, console) : function() {};
 var processKey = function (key) {
   // Stringify keys since we want them as map keys (see #35)

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var toIndexableString = pouchCollate.toIndexableString;
 var normalizeKey = pouchCollate.normalizeKey;
 var createView = require('./create-view');
 var evalFunc = require('./evalfunc');
-var log = (typeof console !== 'undefined') ?
+var log = ((typeof console !== 'undefined') && (typeof console.log === 'function')) ?
   Function.prototype.bind.call(console.log, console) : function () {};
 var utils = require('./utils');
 var taskQueue = new TaskQueue();


### PR DESCRIPTION
Shouldn't try to bind to 'object'...not that `console.log` _should_ be an `object`. But in crappy versions of IE...
