### PR TITLE
Fix to allow list/show functions to be queried

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ function httpQuery(db, fun, opts) {
     var parts = fun.split('/');
     db.request({
       method: method,
-      url: '_design/' + parts[0] + '/_view/' + parts[1] + params,
+      url: parts.length === 2 ? '_design/' + parts[0] + '/_view/' + parts[1] + params : fun + params,
       body: body
     }, callback);
     return;


### PR DESCRIPTION
I can now do this for instance:

```
    db.query('_design/doc-name/_list/list-name/view-name', function(err, body) {
        res.json(err || body);
    });
```
