### PR TITLE
(#69) - avoid POSTs for Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,16 +176,32 @@ function httpQuery(db, fun, opts) {
   addHttpParam('endkey', opts, params, true);
   addHttpParam('key', opts, params, true);
 
-  // If keys are supplied, issue a POST request to circumvent GET query string limits
-  // see http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options
-  if (typeof opts.keys !== 'undefined') {
-    method = 'POST';
-    body = {keys: opts.keys};
-  }
-
   // Format the list of parameters into a valid URI query string
   params = params.join('&');
   params = params === '' ? '' : '?' + params;
+
+  // If keys are supplied, issue a POST request to circumvent GET query string limits
+  // see http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options
+  if (typeof opts.keys !== 'undefined') {
+    var MAX_URL_LENGTH = 2000;
+    // according to http://stackoverflow.com/a/417184/680742,
+    // the de facto URL length limit is 2000 characters
+
+    var keysAsString =
+      'keys=' + encodeURIComponent(JSON.stringify(opts.keys));
+    if (keysAsString.length + params.length + 1 <= MAX_URL_LENGTH) {
+      // If the keys are short enough, do a GET. we do this to work around
+      // Safari not understanding 304s on POSTs (see pouchdb/pouchdb#1239)
+      params += (params[0] === '?' ? '&' : '?') + keysAsString;
+    } else {
+      method = 'POST';
+      if (typeof fun === 'string') {
+        body = JSON.stringify({keys: opts.keys});
+      } else { // fun is {map : mapfun}, so append to this
+        fun.keys = opts.keys;
+      }
+    }
+  }
 
   // We are referencing a query defined in the design doc
   if (typeof fun === 'string') {

--- a/test/test.js
+++ b/test/test.js
@@ -2360,6 +2360,30 @@ function tests(dbName, dbType, viewType) {
           });
         });
       });
+      it('test 304s in Safari (issue 69)', function () {
+        return new Pouch(dbName).then(function (db) {
+          return createView(db, {
+            map : function (doc) {
+              emit(doc.name);
+            }
+          }).then(function (queryFun) {
+            return db.bulkDocs({docs : [
+              {name : 'foo'}
+            ]}).then(function () {
+              return db.query(queryFun, {keys : ['foo']});
+            }).then(function (res) {
+              res.rows.should.have.length(1);
+              return db.query(queryFun, {keys : ['foo']});
+            }).then(function (res) {
+              res.rows.should.have.length(1);
+              return db.query(queryFun, {keys : ['foo']});
+            }).then(function (res) {
+              res.rows.should.have.length(1);
+            });
+          });
+        });
+      });
+
     }
   });
 }


### PR DESCRIPTION
In the version of CouchDB I'm running, I can't actually repro the 304s with POSTs, since CouchDB always returns a 200, but you get the idea.  
