### PR TITLE
(#95) - remove unneeded code

### DIFF
--- a/index.js
+++ b/index.js
@@ -778,7 +778,7 @@ exports.query = function (fun, opts, callback) {
     callback = opts;
     opts = {};
   }
-  opts = utils.clone(opts || {});
+  opts = db.constructor.extend(true, {}, opts || {});
   if (callback) {
     opts.complete = callback;
   }

--- a/utils.js
+++ b/utils.js
@@ -9,38 +9,4 @@ exports.uniq = function (arr) {
   return Object.keys(map);
 };
 
-// shallow clone an object
-exports.clone = function (obj) {
-  if (typeof obj !== 'object') {
-    return obj;
-  }
-  var result = {};
-  Object.keys(obj).forEach(function (key) {
-    result[key] = obj[key];
-  });
-  return result;
-};
-
-
 exports.inherits = require('inherits');
-
-// Promise finally util similar to Q.finally
-exports.fin = function (promise, cb) {
-  return promise.then(function (res) {
-    var promise2 = cb();
-    if (typeof promise2.then === 'function') {
-      return promise2.then(function () {
-        return res;
-      });
-    }
-    return res;
-  }, function (reason) {
-    var promise2 = cb();
-    if (typeof promise2.then === 'function') {
-      return promise2.then(function () {
-        throw reason;
-      });
-    }
-    throw reason;
-  });
-};


### PR DESCRIPTION
We don't need `utils.clone` or `utils.fin`.
