### PR TITLE
(#108) - ensure emit() for user error

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1860,7 +1860,8 @@ function tests(dbName, dbType, viewType) {
     });
     it('should handle user errors in map functions', function () {
       return new Pouch(dbName).then(function (db) {
-        db.on('error', function () { /* noop */ });
+        var err;
+        db.on('error', function (e) { err = e; });
         return createView(db, {
           map : function (doc) {
             emit(doc.nonexistent.foo);
@@ -1870,13 +1871,17 @@ function tests(dbName, dbType, viewType) {
             return db.query(queryFun);
           }).then(function (res) {
             res.rows.should.have.length(0);
+            if (dbType === 'local') {
+              should.exist(err);
+            }
           });
         });
       });
     });
     it('should handle user errors in reduce functions', function () {
       return new Pouch(dbName).then(function (db) {
-        db.on('error', function () { /* noop */ });
+        var err;
+        db.on('error', function (e) { err = e; });
         return createView(db, {
           map : function (doc) {
             emit(doc.name);
@@ -1892,6 +1897,9 @@ function tests(dbName, dbType, viewType) {
             return db.query(queryFun, {reduce: false});
           }).then(function (res) {
             res.rows.map(function (row) {return row.key; }).should.deep.equal(['bar']);
+            if (dbType === 'local') {
+              should.exist(err);
+            }
           });
         });
       });


### PR DESCRIPTION
Turns out your version of the code was fine, @neojski.  We are emitting the error locally when the user has an error in their map or reduce function, which is perfect.

These changes to the tests confirm that we're correctly emitting the error.
