### PR TITLE
(#129) - smarter upsert, only updates doc when necessary

### DIFF
--- a/create-view.js
+++ b/create-view.js
@@ -19,9 +19,12 @@ module.exports = function (opts) {
     // (e.g. when the _design doc is deleted, remove all associated view data)
     function diffFunction(doc) {
       doc.views = doc.views || {};
-      doc.views[viewName] = doc.views[viewName] || {};
-      doc.views[viewName][depDbName] = true;
-      doc._deleted = false;
+      var depDbs = doc.views[viewName] = doc.views[viewName] || {};
+
+      if (depDbs[depDbName]) {
+        return false; // no update necessary
+      }
+      depDbs[depDbName] = true;
       return doc;
     }
     return upsert(sourceDB, '_local/mrviews', diffFunction).then(function () {

--- a/upsert.js
+++ b/upsert.js
@@ -2,8 +2,10 @@
 var Promise = typeof global.Promise === 'function' ? global.Promise : require('lie');
 
 // this is essentially the "update sugar" function from daleharvey/pouchdb#1388
+// the diffFun tells us what delta to apply to the doc.  it either returns
+// the doc, or false if it doesn't need to do an update after all
 function upsert(db, docId, diffFun) {
-  return new Promise(function (fullfil, reject) {
+  return new Promise(function (fulfill, reject) {
     if (docId && typeof docId === 'object') {
       docId = docId._id;
     }
@@ -16,10 +18,13 @@ function upsert(db, docId, diffFun) {
         if (err.name !== 'not_found') {
           return reject(err);
         }
-        return fullfil(tryAndPut(db, diffFun({_id : docId}), diffFun));
+        return fulfill(tryAndPut(db, diffFun({_id : docId}), diffFun));
       }
-      doc = diffFun(doc);
-      fullfil(tryAndPut(db, doc, diffFun));
+      var newDoc = diffFun(doc);
+      if (!newDoc) {
+        return fulfill(doc);
+      }
+      fulfill(tryAndPut(db, newDoc, diffFun));
     });
   });
 }


### PR DESCRIPTION
See pouchdb/pouchdb#1988 for a similar change to `upsert` there.

Also note that `_deleted` is never set to `true` for the `_local/mrviews` doc, so there's no point in setting it to `false`.
