### PR TITLE
(#141) - fixes batched updates

### DIFF
--- a/create-view.js
+++ b/create-view.js
@@ -50,7 +50,7 @@ module.exports = function (opts) {
         };
         return view.db.get('_local/lastSeq').then(null, function (err) {
           if (err.name === 'not_found') {
-            return 0;
+            return {seq: 0};
           }
           throw err;
         }).then(function (lastSeqDoc) {

--- a/index.js
+++ b/index.js
@@ -368,9 +368,9 @@ var updateView = utils.sequentialize(mainQueue, function (view) {
             }
             docIdsToEmits[change.doc._id] = indexableKeysToKeyValues;
           }
+          currentSeq = change.seq;
         }
-        queue.add(processChange(docIdsToEmits, response.last_seq));
-        currentSeq = response.last_seq;
+        queue.add(processChange(docIdsToEmits, currentSeq));
         if (results.length < CHANGES_BATCH_SIZE) {
           return complete();
         }


### PR DESCRIPTION
When @calvinmetcalf ran the coverage tests, he noticed that the number of rows returned from `changes()` was never equal to the batch size (50).  So I rewrote the tests to actually test with changes > 50 and discovered a bug - turns out `last_seq` didn't mean what I thought it meant.  It's fixed now, and there's a test to catch it.
