### PR TITLE
(#89) - fix PouchDB peer dep for real

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "istanbul": "^0.2.7"
   },
   "peerDependencies": {
-    "pouchdb": "^2.0.0"
+    "pouchdb": "^2.2.0"
   },
   "browser": {
     "crypto": false


### PR DESCRIPTION
We need to depend on PouchDB 2.2.0+, because
it added the registerDependentDB stuff which
we now rely on.
