### PR TITLE
(#161) - fix viewCleanup 'ddoc/view' dedup 

### DIFF
--- a/create-view.js
+++ b/create-view.js
@@ -31,7 +31,11 @@ module.exports = function (opts) {
     // (e.g. when the _design doc is deleted, remove all associated view data)
     function diffFunction(doc) {
       doc.views = doc.views || {};
-      var depDbs = doc.views[viewName] = doc.views[viewName] || {};
+      var fullViewName = viewName;
+      if (fullViewName.indexOf('/') === -1) {
+        fullViewName = viewName + '/' + viewName;
+      }
+      var depDbs = doc.views[fullViewName] = doc.views[fullViewName] || {};
       /* istanbul ignore if */
       if (depDbs[depDbName]) {
         return; // no update necessary


### PR DESCRIPTION
There was a problem before with the _local/mrviews
doc, where we weren't putting the fullViewName
(e.g. 'myddoc/myview'), and instaed might put
just the abbreviated name ('myview').  This creates
duplication problems, but it's also something
that viewCleanup() didn't expect, hence errors
in that function.

The fix has an ignored if statement, because that
part is tested in a migration test in pouchdb
proper.
