### PR TITLE
(#159) Don't use relative path for es3ify

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "browserify": {
     "transform": [
-      "./node_modules/es3ify"
+      "es3ify"
     ]
   }
 }


### PR DESCRIPTION
When mapreduce gets pulled in by pouchdb, es3ify sits in pouchdb/node_modules, but doesn't get installed in pouchdb/node_modules/pouchdb-mapreduce/node_modules as well. The transform step will fail. This way we let npm/node handle the module lookup magic.
