### PR TITLE
(pouchdb/pouchdb#2273) - get rid of peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
     "watchify": "~0.4.1",
     "istanbul": "^0.2.7"
   },
-  "peerDependencies": {
-    "pouchdb": "^2.1.0"
-  },
   "browser": {
     "crypto": false
   },


### PR DESCRIPTION
I thought we already got rid of this.

Anyway, we're apparently using the peer dependency
incorrectly for mapreduce, because it breaks
projects that depend on pouchdb when they try
to do `npm shrinkwrap`.

Peer dependencies are designed for true plugins,
not dependencies of the main module. In our
terminology mapreduce is a "plugin," but for
the purposes of npm it's not.
