### PR TITLE
(#134) - allow persistence without ddocs

### DIFF
--- a/create-view.js
+++ b/create-view.js
@@ -10,6 +10,7 @@ module.exports = function (opts) {
   var mapFun = opts.map;
   var reduceFun = opts.reduce;
   var temporary = opts.temporary;
+  var saveAs = opts.saveAs;
 
   // the "undefined" part is for backwards compatibility
   var viewSignature = mapFun.toString() + (reduceFun && reduceFun.toString()) +
@@ -24,32 +25,41 @@ module.exports = function (opts) {
 
   return sourceDB.info().then(function (info) {
 
-    var depDbName = info.db_name + '-mrview-' +
-      (temporary ? 'temp' : utils.MD5(viewSignature));
-
-    // save the view name in the source PouchDB so it can be cleaned up if necessary
-    // (e.g. when the _design doc is deleted, remove all associated view data)
-    function diffFunction(doc) {
-      doc.views = doc.views || {};
-      var fullViewName = viewName;
-      if (fullViewName.indexOf('/') === -1) {
-        fullViewName = viewName + '/' + viewName;
-      }
-      var depDbs = doc.views[fullViewName] = doc.views[fullViewName] || {};
-      /* istanbul ignore if */
-      if (depDbs[depDbName]) {
-        return; // no update necessary
-      }
-      depDbs[depDbName] = true;
-      return doc;
+    var depDbName = info.db_name + '-';
+    if (saveAs) {
+      depDbName += saveAs;
+    } else {
+      depDbName += 'mrview-' + (temporary ? 'temp' : utils.MD5(viewSignature));
     }
-    return upsert(sourceDB, '_local/mrviews', diffFunction).then(function () {
+
+    function registerMrView() {
+      // save the view name in the source PouchDB so it can be cleaned up if necessary
+      // (e.g. when the _design doc is deleted, remove all associated view data)
+      function diffFunction(doc) {
+        doc.views = doc.views || {};
+        var fullViewName = viewName;
+        if (fullViewName.indexOf('/') === -1) {
+          fullViewName = viewName + '/' + viewName;
+        }
+        var depDbs = doc.views[fullViewName] = doc.views[fullViewName] || {};
+        /* istanbul ignore if */
+        if (depDbs[depDbName]) {
+          return; // no update necessary
+        }
+        depDbs[depDbName] = true;
+        return doc;
+      }
+
+      return upsert(sourceDB, '_local/mrviews', diffFunction);
+    }
+
+    function registerDependentDb() {
       return sourceDB.registerDependentDatabase(depDbName).then(function (res) {
         var db = res.db;
         db.auto_compaction = true;
         var view = {
           name: depDbName,
-          db: db, 
+          db: db,
           sourceDB: sourceDB,
           adapter: sourceDB.adapter,
           mapFun: mapFun,
@@ -61,17 +71,24 @@ module.exports = function (opts) {
             throw err;
           }
         }).then(function (lastSeqDoc) {
-          view.seq = lastSeqDoc ? lastSeqDoc.seq : 0;
-          if (!temporary) {
-            sourceDB._cachedViews = sourceDB._cachedViews || {};
-            sourceDB._cachedViews[viewSignature] = view;
-            view.db.on('destroyed', function () {
-              delete sourceDB._cachedViews[viewSignature];
-            });
-          }
-          return view;
-        });
+            view.seq = lastSeqDoc ? lastSeqDoc.seq : 0;
+            if (!temporary) {
+              sourceDB._cachedViews = sourceDB._cachedViews || {};
+              sourceDB._cachedViews[viewSignature] = view;
+              view.db.on('destroyed', function () {
+                delete sourceDB._cachedViews[viewSignature];
+              });
+            }
+            return view;
+          });
       });
-    });
+    }
+
+    return Promise.resolve().then(function () {
+      if (viewName) {
+        return registerMrView();
+      }
+      return Promise.resolve();
+    }).then(registerDependentDb);
   });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -22,9 +22,27 @@ if (process.browser) {
 
 dbs.split(',').forEach(function (db) {
   var dbType = /^http/.test(db) ? 'http' : 'local';
-  var viewTypes = ['persisted', 'temp'];
+  var viewTypes = [
+    {
+      persisted: true,
+      auto: false
+    },
+    {
+      persisted: false
+    }
+  ];
+  if (dbType === 'local') {
+    // doesn't make sense on http
+    viewTypes.push({
+      persisted: true,
+      auto: true
+    });
+  }
   viewTypes.forEach(function (viewType) {
-    describe(dbType + ' with ' + viewType + ' views:', function () {
+
+    describe(dbType + ' with ' + (viewType.auto ? 'auto-' : '') +
+        (viewType.persisted ? 'persisted' : 'temp') +
+        ' views:', function () {
       tests(db, dbType, viewType);
     });
   });
@@ -93,7 +111,7 @@ describe('utils', function () {
 function tests(dbName, dbType, viewType) {
 
   var createView;
-  if (viewType === 'persisted') {
+  if (viewType.persisted && !viewType.auto) {
     createView = function (db, viewObj) {
       var storableViewObj = {
         map : viewObj.map.toString()
@@ -118,6 +136,9 @@ function tests(dbName, dbType, viewType) {
     };
   } else {
     createView = function (db, viewObj) {
+      if (viewType.auto) {
+        viewObj.saveAs = 'custom-' + Pouch.utils.MD5(viewObj.toString());
+      }
       return new Promise(function (resolve) {
         process.nextTick(function () {
           resolve(viewObj);
@@ -165,7 +186,7 @@ function tests(dbName, dbType, viewType) {
         });
       });
     });
-    if (dbType === 'local' && viewType === 'temp') {
+    if (dbType === 'local' && !viewType.persisted) {
       it("with a closure", function () {
         return new Pouch(dbName).then(function (db) {
           return db.bulkDocs({docs: [
@@ -194,7 +215,7 @@ function tests(dbName, dbType, viewType) {
         });
       });
     }
-    if (viewType === 'temp') {
+    if (!viewType.persisted) {
 
       it('Test simultaneous temp views', function () {
         return new Pouch(dbName).then(function (db) {
@@ -625,7 +646,7 @@ function tests(dbName, dbType, viewType) {
       });
     });
 
-    if (viewType === 'temp') {
+    if (!viewType.persisted) {
       it("No reduce function, passing just a function", function () {
         return new Pouch(dbName).then(function (db) {
           return db.post({foo: 'bar'}).then(function () {
@@ -810,7 +831,7 @@ function tests(dbName, dbType, viewType) {
       });
     });
 
-    if (viewType === 'persisted') {
+    if (viewType.persisted) {
 
       it('Returns ok for viewCleanup on empty db', function () {
         return new Pouch(dbName).then(function (db) {
@@ -1437,7 +1458,7 @@ function tests(dbName, dbType, viewType) {
       });
     });
 
-    if (viewType === 'persisted') {
+    if (viewType.persisted) {
       it('should error with a callback', function (done) {
         new Pouch(dbName, function (err, db) {
           db.query('fake/thing', function (err) {
@@ -2060,7 +2081,7 @@ function tests(dbName, dbType, viewType) {
       });
     });
 
-    if (viewType === 'persisted') {
+    if (viewType.persisted) {
       it('should query correctly when stale', function () {
         return new Pouch(dbName).then(function (db) {
           return createView(db, {
@@ -2621,7 +2642,7 @@ function tests(dbName, dbType, viewType) {
       });
     });
 
-    if (viewType === 'persisted') {
+    if (viewType.persisted) {
 
       it('should delete duplicate indexes', function () {
         this.timeout(5000);
@@ -2798,6 +2819,64 @@ function tests(dbName, dbType, viewType) {
               return db.query(queryFun, {keys : ['foo']});
             }).then(function (res) {
               res.rows.should.have.length(1);
+            });
+          });
+        });
+      });
+    }
+
+    if (viewType.persisted && viewType.auto) {
+      it('allows us to auto-persist data, with closures', function () {
+        this.timeout(10000);
+        return new Pouch(dbName).then(function (db) {
+          var val = 'foo';
+          return createView(db, {
+            map: function (doc, emit) {
+              emit(val);
+            }
+          }).then(function (queryFun) {
+            var saveAs = queryFun.saveAs;
+            return db.bulkDocs({docs: [{}]}).then(function () {
+              return db.query(queryFun);
+            }).then(function (res) {
+              res.rows.should.have.length(1);
+              res.rows[0].key.should.equal('foo');
+              var randomFun = {
+                map : function () {
+                  emit('whatever');
+                }
+              };
+              return db.query(randomFun, {saveAs: saveAs});
+            }).then(function (res) {
+              // since we used the same saveAs, it should just give us the
+              // old results
+              res.rows.should.have.length(1);
+              res.rows[0].key.should.equal('foo');
+            });
+          });
+        });
+      });
+
+      it('allows us to delete auto-persisted data', function () {
+        this.timeout(10000);
+        return new Pouch(dbName).then(function (db) {
+          var val = 'foo';
+          return createView(db, {
+            map: function (doc, emit) {
+              emit(val);
+            }
+          }).then(function (queryFun) {
+            var saveAs = queryFun.saveAs;
+            return db.bulkDocs({docs: [{}]}).then(function () {
+              return db.query(queryFun).then(function (res) {
+                res.rows.should.have.length(1);
+                res.rows[0].key.should.equal('foo');
+                return db.query(queryFun, {saveAs: saveAs, destroy: true});
+              }).then(function () {
+                return db.query(queryFun, {saveAs: saveAs, stale: 'ok'});
+              }).then(function (res) {
+                res.rows.should.have.length(0);
+              });
             });
           });
         });


### PR DESCRIPTION
So here's an alternative idea for how we could handle the need for plugins to persist data without needing to save their own design doc.

Instead of breaking out persistence into a separate plugin (which would be very difficult, given all the hooks for deleting external DBs on `viewCleanup()` when their parent ddoc is deleted, as well as various other ddoc-specific code), I just punched a hole in the `query()` API, which allows you to set the option `{saveAs: 'foobar'}`, which will then persist whatever map/reduce function you give it, and it will be saved to an external DB called `<dbname>-foobar` instead of `<dbname>-mrview-<md5sum>`.

Best of all, you can pass a closure in as the map function, meaning that the search plugin can call lunr if it wants to, and the geo plugin could do whatever crazy transforms it wants to do before emitting.  But in principle everything is still just map/reduce under the hood, and anything map/reduce can do, this function can do.

In the code, I also made it so you can either set `saveAs` on the map/reduce function or in the options, simply because it made the tests easier to write.  But I also like it because it reduces the possibility of user error.

Thoughts?
