### PR TITLE
(#188) - update_after nextTick optimization

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,13 @@ if ((typeof console !== 'undefined') && (typeof console.log === 'function')) {
 }
 var utils = require('./utils');
 var Promise = utils.Promise;
+var nextTick;
+/* istanbul ignore else */
+if (global.setImmediate) {
+  nextTick = global.setImmediate;
+} else {
+  nextTick = process.nextTick;
+}
 var mainQueue = new TaskQueue();
 var tempViewQueue = new TaskQueue();
 var CHANGES_BATCH_SIZE = 50;
@@ -680,7 +687,9 @@ function queryPromised(db, fun, opts) {
       return createView(createViewOpts).then(function (view) {
         if (opts.stale === 'ok' || opts.stale === 'update_after') {
           if (opts.stale === 'update_after') {
-            updateView(view);
+            nextTick(function () {
+              updateView(view);
+            });
           }
           return queryView(view, opts);
         } else { // stale not ok


### PR DESCRIPTION
A small oversight we made before - much of
updateView() is run synchronously, so we
can speed up update_after calls a bit by
putting that logic into setImmediate or
nextTick.
