### PR TITLE
(#191) - parse the indexable string

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,7 +281,10 @@ function getDocsToPersist(docId, view, docIdsToEmits) {
           oldKeysMap[kvDoc._id] = true;
           kvDoc._deleted = !indexableKeysToKeyValues[kvDoc._id];
           if (!kvDoc._deleted) {
-            kvDoc.value = indexableKeysToKeyValues[kvDoc._id];
+            var keyValue = indexableKeysToKeyValues[kvDoc._id];
+            if ('value' in keyValue) {
+              kvDoc.value = keyValue.value;
+            }
           }
         });
 
@@ -289,10 +292,14 @@ function getDocsToPersist(docId, view, docIdsToEmits) {
         newKeys.forEach(function (key) {
           if (!oldKeysMap[key]) {
             // new doc
-            kvDocs.push({
-              _id: key,
-              value: indexableKeysToKeyValues[key]
-            });
+            var kvDoc = {
+              _id: key
+            };
+            var keyValue = indexableKeysToKeyValues[key];
+            if ('value' in keyValue) {
+              kvDoc.value = keyValue.value;
+            }
+            kvDocs.push(kvDoc);
           }
         });
         metaDoc.keys = utils.uniq(newKeys.concat(metaDoc.keys));
@@ -337,6 +344,8 @@ var updateView = utils.sequentialize(mainQueue, function (view) {
 
   function emit(key, value) {
     var output = { id: doc._id, key: normalizeKey(key) };
+    // Don't explicitly store the value unless it's defined and non-null.
+    // This saves on storage space, because often people don't use it.
     if (typeof value !== 'undefined' && value !== null) {
       output.value = normalizeKey(value);
     }
@@ -488,18 +497,33 @@ var queryView = utils.sequentialize(mainQueue, function (view, opts) {
     return view.db.allDocs(viewOpts).then(function (res) {
       totalRows = res.total_rows;
       return res.rows.map(function (result) {
-        return result.doc.value;
+
+        // implicit migration - in older versions of PouchDB,
+        // we explicitly stored the doc as {id: ..., key: ..., value: ...}
+        // this is tested in a migration test
+        /* istanbul ignore next */
+        if ('value' in result.doc && typeof result.doc.value === 'object' &&
+            result.doc.value !== null) {
+          var keys = Object.keys(result.doc.value).sort();
+          // this detection method is not perfect, but it's unlikely the user
+          // emitted a value which was an object with these 3 exact keys
+          var expectedKeys = ['id', 'key', 'value'];
+          if (!(keys < expectedKeys || keys > expectedKeys)) {
+            return result.doc.value;
+          }
+        }
+
+        var parsedKeyAndDocId = pouchCollate.parseIndexableString(result.doc._id);
+        return {
+          key: parsedKeyAndDocId[0],
+          id: parsedKeyAndDocId[1],
+          value: ('value' in result.doc ? result.doc.value : null)
+        };
       });
     });
   }
 
   function onMapResultsReady(results) {
-    results.forEach(function (result) {
-      // we don't persist the value if it's null, so set it now
-      if (!('value' in result)) {
-        result.value = null;
-      }
-    });
     var res;
     if (shouldReduce) {
       res = reduceView(view, results, opts);


### PR DESCRIPTION
I'm testing to see if we can get any performance benefits from parsing the indexable string (in order to get the doc id and key) rather than explicitly writing out the docid and key.  Even if we don't get a performance boost, it'll take up less space on disk, which is a win.
