### PR TITLE
(#198) - update_after should actually update after

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,6 +179,7 @@ function httpQuery(db, fun, opts) {
   addHttpParam('group', opts, params);
   addHttpParam('group_level', opts, params);
   addHttpParam('skip', opts, params);
+  addHttpParam('stale', opts, params);
   addHttpParam('startkey', opts, params, true);
   addHttpParam('endkey', opts, params, true);
   addHttpParam('inclusive_end', opts, params);
@@ -680,7 +681,9 @@ function queryPromised(db, fun, opts) {
       return createView(createViewOpts).then(function (view) {
         if (opts.stale === 'ok' || opts.stale === 'update_after') {
           if (opts.stale === 'update_after') {
-            updateView(view);
+            process.nextTick(function () {
+              updateView(view);
+            });
           }
           return queryView(view, opts);
         } else { // stale not ok

--- a/test/test.js
+++ b/test/test.js
@@ -2096,6 +2096,7 @@ function tests(dbName, dbType, viewType) {
 
     if (viewType === 'persisted') {
       it('should query correctly when stale', function () {
+        this.timeout(20000);
         return new Pouch(dbName).then(function (db) {
           return createView(db, {
             map : function (doc) {
@@ -2147,13 +2148,39 @@ function tests(dbName, dbType, viewType) {
               res.rows.length.should.equal(1);
               ['baz', 'bar'].indexOf(res.rows[0].key).should.be.above(-1,
                 'key might be stale, thats ok');
-              return setTimeoutPromise(5);
+              return setTimeoutPromise(1000);
             }).then(function () {
               return db.query(queryFun, {stale : 'ok'});
             }).then(function (res) {
               res.rows.length.should.equal(1);
               res.rows[0].key.should.equal('baz');
             });
+          });
+        });
+      });
+
+      it('should query correctly with stale update_after', function () {
+        this.timeout(20000);
+        var pouch = new Pouch(dbName);
+
+        return createView(pouch, {map: function (doc) {
+          emit(doc.foo);
+        }}).then(function (queryFun) {
+          var docs = [];
+
+          for (var i = 0; i < 10; i++) {
+            docs.push({foo: 'bar'});
+          }
+
+          return pouch.bulkDocs(docs).then(function () {
+            return pouch.query(queryFun, {stale: 'update_after'});
+          }).then(function (res) {
+            res.rows.should.have.length(0, 'query() returned immediately');
+            return setTimeoutPromise(1000);
+          }).then(function () {
+            return pouch.query(queryFun, {stale: 'ok'});
+          }).then(function (res) {
+            res.rows.should.have.length(10, 'index was built in background');
           });
         });
       });


### PR DESCRIPTION
It seems there was a bug where update_after wouldn't
actually cause the query to return immediately, and
instead would still force the user to wait for the
results to be built up.  This fixes that.
