### PR TITLE
(#232) - greppable node tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
     "url": "git://github.com/pouchdb/mapreduce.git"
   },
   "scripts": {
-    "test-node": "TEST_DB=testdb,http://localhost:5984/testdb istanbul test ./node_modules/mocha/bin/_mocha test/test.js",
+    "test-for-coverage": "TEST_DB=testdb,http://localhost:5984/testdb istanbul test ./node_modules/mocha/bin/_mocha test/test.js",
+    "test-node": "TEST_DB=testdb,http://localhost:5984/testdb mocha --reporter=spec --grep=$GREP test/test.js",
     "test-browser": "./bin/test-browser.js",
     "jshint": "jshint -c .jshintrc *.js test/test.js",
     "test": "npm run jshint && ./bin/run-test.sh",
     "build": "mkdir -p dist && browserify index.js -s mapReduce -o dist/pouchdb-mapreduce.js",
     "dev": "browserify test/test.js > test/test-bundle.js && npm run dev-server",
     "dev-server": "./bin/dev-server.js",
-    "coverage": "npm test --coverage && istanbul check-coverage --lines 100 --function 100 --statements 100 --branches 100"
+    "coverage": "npm run test-for-coverage --coverage && istanbul check-coverage --lines 100 --function 100 --statements 100 --branches 100"
   },
   "keywords": [
     "pouch",

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ Map/reduce plugin pulled out of PouchDB.  A PouchDB plugin that, like [PouchDB C
 Building
 ----
 
+    npm install
     npm run build
 
 Testing
@@ -13,14 +14,24 @@ Testing
 
 ### In Node
 
-Run tests with `npm test` and coverage of tests with `npm test --coverage` install dependencies with `npm install`
+    npm test
 
-If you have mocha installed globally you can run single test with:
-```
-TEST_DB=local mocha --reporter spec --grep search_phrase
-```
-In TEST_DB environment variable specify database that PouchDB should use (see package.json)
+To run coverage tests:
+
+    npm run coverage
+
+To run individual tests:
+
+    GREP=my_search_term npm test
 
 ### In the browser
 
-Run `npm run dev` and then point your favorite browser to [http://127.0.0.1:8001/test/index.html](http://127.0.0.1:8001/test/index.html).
+Run 
+
+    npm run dev
+    
+and then point your favorite browser to [http://127.0.0.1:8001/test/index.html](http://127.0.0.1:8001/test/index.html).
+
+To run individual tests, load e.g.:
+
+    http://127.0.0.1:8001/test/index.html?grep=my_search_term


### PR DESCRIPTION
Not being able to do `GREP=grep npm test` has been bumming me out.
