### PR TITLE
coffeescript view support

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,16 @@ var mainQueue = new TaskQueue();
 var tempViewQueue = new TaskQueue();
 var CHANGES_BATCH_SIZE = 50;
 
+var coffee;
+try {
+  coffee = require('coffee-script');
+}
+catch (e) {
+  if (typeof window !== 'undefined' && window.CoffeeScript) {
+    coffee = window.CoffeeScript;
+  }
+}
+
 function parseViewName(name) {
   // can be either 'ddocname/viewname' or just 'viewname'
   // (where the ddoc name is the same)
@@ -731,6 +741,19 @@ function queryPromised(db, fun, opts) {
       }
       checkQueryParseError(opts, fun);
 
+      if (doc.language === 'coffeescript' && coffee) {
+        if (typeof fun.map === 'string') {
+          fun.map = coffee.compile(fun.map, {bare: true});
+        }
+        if (typeof fun.reduce === 'string') {
+          fun.reduce = coffee.compile(fun.reduce, {bare: true});
+        }
+      }
+      else if (doc.language && doc.language !== 'javascript') {
+        throw new NotSupportedError('view language ' + doc.language +
+          ' is not supported')
+      }
+
       var createViewOpts = {
         db : db,
         viewName : fullViewName,
@@ -785,6 +808,18 @@ function QueryParseError(message) {
 }
 
 utils.inherits(QueryParseError, Error);
+
+function NotSupportedError(message) {
+  this.status = 500;
+  this.name = 'not_supported_error';
+  this.message = message;
+  this.error = true;
+  try {
+    Error.captureStackTrace(this, NotSupportedError);
+  } catch (e) {}
+}
+
+utils.inherits(NotSupportedError, Error);
 
 function NotFoundError(message) {
   this.status = 404;


### PR DESCRIPTION
Hi there,

I've thrown together a quick POC for coffeescript view support. It doesn't bundle coffeescript in core (that would be nuts) but detects if it's require-able or present on `window`. This should allow people who want coffeescript views (like pouchdb/pouchdb#2754) to include coffeescript themselves and have it automatically enabled, without increasing the payload much for other users.

What do you think? If you like the general direction I'm happy to add tests and things.