### PR TITLE
(#247) - Add PouchDB server to Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 coverage
 test/test-bundle.js
 npm-debug.log
+testdata

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ before_script:
   - "curl -X GET http://127.0.0.1:5984/"
   - "curl -X PUT http://127.0.0.1:5984/_config/log/level -d '\"debug\"'"
 
-    # pouchdb-server setup
-  - "rm -rf node_modules/pouchdb-server/node_modules/pouchdb/node_modules/mapreduce"
-  - "ln -s ../../../../.. node_modules/pouchdb-server/node_modules/pouchdb/node_modules/mapreduce"
-
 after_failure:
   - "curl -X GET http://127.0.0.1:5984/_log?bytes=1000000"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,23 @@ before_script:
   - "curl -X GET http://127.0.0.1:5984/"
   - "curl -X PUT http://127.0.0.1:5984/_config/log/level -d '\"debug\"'"
 
+    # pouchdb-server setup
+  - "rm -rf node_modules/pouchdb-server/node_modules/pouchdb/node_modules/mapreduce"
+  - "ln -s ../../../../.. node_modules/pouchdb-server/node_modules/pouchdb/node_modules/mapreduce"
+
 after_failure:
   - "curl -X GET http://127.0.0.1:5984/_log?bytes=1000000"
 
 env:
   matrix:
   - COMMAND=test
+  - SERVER=pouchdb-server COMMAND=test
   - CLIENT=selenium:firefox COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
   - COMMAND=coverage
+
+
+matrix:
+  allow_failures:
+  - env: SERVER=pouchdb-server COMMAND=test
+  fast_finish: true

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -4,6 +4,11 @@
 
 if [ "$SERVER" == "pouchdb-server" ]; then
     mkdir -p ./testdata/server
+    if [ "$TRAVIS_REPO_SLUG" == "pouchdb/mapreduce" ]; then
+      # pouchdb-server setup
+      rm -rf node_modules/pouchdb-server/node_modules/pouchdb/node_modules/mapreduce
+      ln -s ../../../../.. node_modules/pouchdb-server/node_modules/pouchdb/node_modules/mapreduce
+    fi
     echo '{
         "httpd": {
             "port": 5985

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -2,8 +2,34 @@
 
 : ${CLIENT:="node"}
 
+if [ "$SERVER" == "pouchdb-server" ]; then
+    mkdir -p ./testdata/server
+    echo '{
+        "httpd": {
+            "port": 5985
+        },
+        "couchdb": {
+            "database_dir": "./testdata/server"
+        },
+        "log": {
+            "file": "./testdata/server/log.txt"
+        }
+    }' > ./testdata/server/config.json
+    ./node_modules/.bin/pouchdb-server -c ./testdata/server/config.json &
+    export POUCHDB_SERVER_PID=$!
+    : ${TEST_DB:="./testdata/client/testdb,http://localhost:5985/testdb"}
+    export TEST_DB
+    sleep 5
+fi
+
 if [ "$CLIENT" == "node" ]; then
     npm run test-node
 else
     npm run test-browser
 fi
+
+EXIT_STATUS=$?
+if [[ ! -z $POUCHDB_SERVER_PID ]]; then
+  kill $POUCHDB_SERVER_PID
+fi
+exit $EXIT_STATUS

--- a/bin/test-node.sh
+++ b/bin/test-node.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+: ${TEST_DB:="testdb,http://localhost:5984/testdb"}
+export TEST_DB
+mocha --reporter=spec --grep=$GREP test/test.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test-for-coverage": "TEST_DB=testdb,http://localhost:5984/testdb istanbul test ./node_modules/mocha/bin/_mocha test/test.js",
-    "test-node": "TEST_DB=testdb,http://localhost:5984/testdb mocha --reporter=spec --grep=$GREP test/test.js",
+    "test-node": "./bin/test-node.sh",
     "test-browser": "./bin/test-browser.js",
     "jshint": "jshint -c .jshintrc *.js test/test.js",
     "test": "npm run jshint && ./bin/run-test.sh",
@@ -53,6 +53,7 @@
     "phantomjs": "^1.9.7-5",
     "pouchdb": "pouchdb/pouchdb",
     "pouchdb-http-proxy": "~0.10.3",
+    "pouchdb-server": "^0.6.4",
     "request": "^2.34.0",
     "sauce-connect-launcher": "^0.4.2",
     "watchify": "~0.4.1",


### PR DESCRIPTION
Tests fail against PouchDB server, so it's in the allowed failures list. Also
stores all test db files at a central place 'testdata'.