### PR TITLE
(pouchdb/pouchdb#3688) - get rid of es3ify

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "argsarray": "0.0.1",
-    "es3ify": "^0.1.3",
     "inherits": "~2.0.1",
     "lie": "^2.6.0",
     "pouchdb-collate": "^1.2.0",
@@ -62,10 +61,5 @@
   },
   "browser": {
     "crypto": false
-  },
-  "browserify": {
-    "transform": [
-      "es3ify"
-    ]
   }
 }


### PR DESCRIPTION
See pouchdb/pouchdb#3720 for details. If we only use es3ify
as a build-time step, then there's no reason to
need to include it in all our dependencies.